### PR TITLE
Fix connection timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ datasource = Druid::DataSource.new('datasource_name', 'http://broker-host:8080/d
 
 | key                 | description                                        | type   | default      |
 | ------------------- | -------------------------------------------------- | ------ | ------------ |
-| :connection_timeout | connection timeout for druid services (in seconds) | int    | 60           |
+| :open_timeout       | open timeout for druid services (in seconds)       | int    | 60           |
 | :read_timeout       | read timeout for druid services (in seconds)       | int    | nil          |
 | :discovery_path     | druid service discovery path in zookeeper          | string | '/discovery' |
 

--- a/lib/druid/client.rb
+++ b/lib/druid/client.rb
@@ -7,12 +7,13 @@ module Druid
     attr_reader :zk
 
     def initialize(zookeeper, opts = {})
+      @opts = opts
       @zk = ZK.new(zookeeper, opts)
     end
 
     def data_source(source)
       uri = @zk.data_sources[source]
-      Druid::DataSource.new(source, uri)
+      Druid::DataSource.new(source, uri, @opts)
     end
 
     def data_sources

--- a/lib/druid/data_source.rb
+++ b/lib/druid/data_source.rb
@@ -8,7 +8,7 @@ module Druid
 
     def initialize(name, uri, opt = {})
       @name = name.split('/').last
-      @connection_timeout = opt[:connection_timeout] || 10 # if druid is down fail fast
+      @open_timeout = opt[:open_timeout] || 10 # if druid is down fail fast
       @read_timeout = opt[:read_timeout] # we wait until druid is finished
       uri = uri.sample if uri.is_a?(Array)
       if uri.is_a?(String)
@@ -36,7 +36,7 @@ module Druid
       req = Net::HTTP::Get.new(meta_path)
 
       http = Net::HTTP.new(uri.host, uri.port)
-      http.open_timeout = @connection_timeout
+      http.open_timeout = @open_timeout
       http.read_timeout = @read_timeout
       response = http.start { |h| h.request(req) }
 
@@ -64,7 +64,7 @@ module Druid
       req.body = query.to_json
 
       http = Net::HTTP.new(uri.host, uri.port)
-      http.open_timeout = @connection_timeout
+      http.open_timeout = @open_timeout
       http.read_timeout = @read_timeout
       response = http.start { |h| h.request(req) }
 


### PR DESCRIPTION
- fix connection and read timeout. Expected behaviour is that connection timeout is 10 seconds. But really it was still 60 seconds. The reason is that `Net::Http.start` method [starts](https://github.com/ruby/ruby/blob/trunk/lib/net/http.rb#L876) connection with default current timeouts and than [applies](https://github.com/ruby/ruby/blob/trunk/lib/net/http.rb#L877) passed block.
- allow to configure `connection_timeout` and `read_timeout`.
- fix outdated usage examples in README (https://github.com/ruby-druid/ruby-druid/issues/7).
- add example of connection to static host rather than using zookeeper service discovery.
